### PR TITLE
Refactor Strategy to keep function inside him

### DIFF
--- a/group.go
+++ b/group.go
@@ -4,15 +4,29 @@ import (
 	"fmt"
 )
 
+func abortStrategy(cmdList []Command) (execCount int, err error) {
+	for _, cmd := range cmdList {
+		_, cmdErr := cmd.Run()
+
+		if cmdErr != nil {
+			err = fmt.Errorf("Error running a command: %v", cmdErr)
+			break
+		}
+
+		execCount++
+	}
+	return
+}
+
 // Strategy contains details about action to take when a
 // command fail inside a group execution
-type Strategy string
+type Strategy (func([]Command) (int, error))
 
-const (
+var (
 	// AbortOnError is a strategy to run grouped commands
 	// This stategy end the group execution resulting a error and output.
 	// It is the default option.
-	AbortOnError Strategy = "ABORT"
+	AbortOnError Strategy = abortStrategy
 
 	// // IgnoreOnError is a strategy to run grouped commands
 	// // This strategy ignores the problem
@@ -22,27 +36,5 @@ const (
 // Group allows to run lots of commands in sequence
 // The strategy defines the behavior when a error occours
 func Group(strategy Strategy, cmdList ...Command) (execCount int, err error) {
-
-	var rFunc (func([]Command) (int, error))
-
-	// if strategy == AbortOnError {
-	rFunc = abortGroup
-	// }
-
-	return rFunc(cmdList)
-}
-
-func abortGroup(cmdList []Command) (execCount int, err error) {
-	for _, cmd := range cmdList {
-		_, cmdErr := cmd.Run()
-
-		if cmdErr != nil {
-			err = fmt.Errorf("Error running a command: %v", cmdErr)
-
-			break
-		}
-
-		execCount++
-	}
-	return
+	return strategy(cmdList)
 }

--- a/group_test.go
+++ b/group_test.go
@@ -28,7 +28,7 @@ var (
 	}
 )
 
-func Test_abortGroup(t *testing.T) {
+func Test_abortStrategy(t *testing.T) {
 	type args struct {
 		cmdList []Command
 	}
@@ -57,7 +57,7 @@ func Test_abortGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotExecCount, err := abortGroup(tt.args.cmdList)
+			gotExecCount, err := abortStrategy(tt.args.cmdList)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("abortGroup() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
So we don't need revalidate this type to execute strategy.